### PR TITLE
Fix missing brace in captura validation

### DIFF
--- a/captura.js
+++ b/captura.js
@@ -386,11 +386,14 @@ function validarFormulario(){
     if (mesYaCapturado) {
         const nombreMes = MESES[mes - 1];
         const valorActual = formatearNumero(mesYaCapturado.valor);
-        
+
         mostrarNotificacion(
-            `${nombreMes} ya está capturado con valor: ${valorActual}. Use el botón "Editar" en la tabla para modificarlo.`, 
+            `${nombreMes} ya está capturado con valor: ${valorActual}. Use el botón "Editar" en la tabla para modificarlo.`,
             "info"
         );
+
+        return false;
+    }
       
     // Validación específica para CAPTURISTA
     if (currentUser?.rol === ROLES.CAPTURISTA) {


### PR DESCRIPTION
## Summary
- ensure the form validation branch for duplicated months returns early and closes correctly

## Testing
- node -e "new Function(require('fs').readFileSync('captura.js','utf8'))"


------
https://chatgpt.com/codex/tasks/task_e_68cc85fc1bd8832eb80bb83661d94b73