### PR TITLE
Fix missing closing brace in captura.js

### DIFF
--- a/captura.js
+++ b/captura.js
@@ -250,7 +250,7 @@ async function cargarDatos(){
     mostrarNotificacion("Error al cargar datos", "error");
   } finally {
     actualizarEstadoBotonGuardar();
-    
+
     // Mostrar información de datos cargados
     if (capturaData.datosActuales && capturaData.datosActuales.length > 0) {
       const mesesConDatos = capturaData.datosActuales.filter(d => d.valor && d.valor > 0).length;
@@ -258,8 +258,8 @@ async function cargarDatos(){
         mostrarNotificacion(`${mesesConDatos} meses con datos cargados`, "info", 2000);
       }, 500);
     }
-  
-  
+  }
+
 }
 
 // ====================================


### PR DESCRIPTION
## Summary
- close the `async cargarDatos` function in `captura.js` by adding the missing brace

## Testing
- node --check captura.js

------
https://chatgpt.com/codex/tasks/task_e_68cd69d0f910832e9a5a4b70dca74a52